### PR TITLE
Sets up automated npm publishing on tagged commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Lint (prepublish checks)
+        run: pnpm run lint -c .eslintrc.prepublish.js nodes credentials package.json
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --no-git-checks
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-gh-models",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Github cung cấp một lượng request miễn phí nhất định đến các AI model nổi tiếng. Node này thay thế quá trình tích hợp bằng http request phức tạp.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Configures a GitHub Actions workflow to automatically publish the package to npm when a new tag is pushed.

This ensures that new versions are automatically released to npm, triggered by tagging commits with version numbers.

Includes linting checks before publishing.
